### PR TITLE
Send data with NO RESPONSE on BLERemoteCharacteristic

### DIFF
--- a/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -100,11 +100,11 @@ uint32_t BLERemoteCharacteristic::readData32() {
 
 //--------- Write Char Value --------//
 
-bool BLERemoteCharacteristic::writeString(String str) {
+bool BLERemoteCharacteristic::writeString(String str, T_GATT_WRITE_TYPE type) {
     return writeString(str.c_str());
 }
 
-bool BLERemoteCharacteristic::writeString(const char* str) {
+bool BLERemoteCharacteristic::writeString(const char* str, T_GATT_WRITE_TYPE type) {
     return setData((uint8_t*) str, strlen(str));
 }
 
@@ -126,7 +126,7 @@ bool BLERemoteCharacteristic::writeData32(int num) {
 
 //------------ Modify Char ------------//
 
-bool BLERemoteCharacteristic::setData(uint8_t* data, uint16_t datalen) {
+bool BLERemoteCharacteristic::setData(uint8_t* data, uint16_t datalen, T_GATT_WRITE_TYPE type) {
     if (!canWrite()) {
         printf("Characteristic %s error: write not permitted \n", _uuid.str());
         return false;
@@ -137,7 +137,7 @@ bool BLERemoteCharacteristic::setData(uint8_t* data, uint16_t datalen) {
         return false;
     }
     // Attempt to write
-    if (client_attr_write(_pClient->getConnId(), _pClient->getClientId(),  GATT_WRITE_TYPE_REQ, _valueHandle, datalen, data) == GAP_CAUSE_SUCCESS) {
+    if (client_attr_write(_pClient->getConnId(), _pClient->getClientId(),  type, _valueHandle, datalen, data) == GAP_CAUSE_SUCCESS) {
         // Check for write callback semaphore indicating data write successful
         if (xSemaphoreTake(_writeSemaphore, CB_WAIT_TIMEOUT/portTICK_PERIOD_MS) != pdTRUE) {
             printf("Characteristic %s error: set data timeout \n", _uuid.str());

--- a/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -101,11 +101,11 @@ uint32_t BLERemoteCharacteristic::readData32() {
 //--------- Write Char Value --------//
 
 bool BLERemoteCharacteristic::writeString(String str, T_GATT_WRITE_TYPE type) {
-    return writeString(str.c_str());
+    return writeString(str.c_str(), type);
 }
 
 bool BLERemoteCharacteristic::writeString(const char* str, T_GATT_WRITE_TYPE type) {
-    return setData((uint8_t*) str, strlen(str));
+    return setData((uint8_t*) str, strlen(str), type);
 }
 
 bool BLERemoteCharacteristic::writeData8(uint8_t num) {

--- a/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/Arduino_package/hardware/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -43,15 +43,15 @@ class BLERemoteCharacteristic {
         uint32_t readData32();
 
         //---------- Write Char Value ---------//
-        bool writeString(String str);
-        bool writeString(const char* str);
+        bool writeString(String str, T_GATT_WRITE_TYPE type = GATT_WRITE_TYPE_REQ);
+        bool writeString(const char* str, T_GATT_WRITE_TYPE type = GATT_WRITE_TYPE_REQ);
         bool writeData8(uint8_t num);
         bool writeData16(uint16_t num);
         bool writeData32(uint32_t num);
         bool writeData32(int num);
 
         //------------ Modify Char ------------//
-        bool setData(uint8_t* data, uint16_t datalen);
+        bool setData(uint8_t* data, uint16_t datalen, T_GATT_WRITE_TYPE type = GATT_WRITE_TYPE_REQ);
         uint16_t getData(uint8_t* data, uint16_t datalen);
         void enableNotifyIndicate(bool notify = 1);
         void disableNotifyIndicate();


### PR DESCRIPTION
In BLECharacteristic, we already have setWriteProperty() and setWriteNRProperty().
But the coresponded BLERemoteCharacteristic can only send data to when setWriteProperty() is used.
According to "profile_client.h", there are GATT_WRITE_TYPE_REQ and GATT_WRITE_TYPE_CMD that can distinguish these two.
Modify BLERemoteCharacteristic.h and BLERemoteCharacteristic.cpp to add this function.
