### PR TITLE
Update BLEDevice.cpp

### DIFF
--- a/Arduino_package/hardware/libraries/BLE/src/BLEDevice.cpp
+++ b/Arduino_package/hardware/libraries/BLE/src/BLEDevice.cpp
@@ -265,7 +265,7 @@ void BLEDevice::beginPeripheral() {
     if (BTDEBUG) printf("GAP cb reg\r\n");
 
     // start BLE main task to handle IO and GAP msg
-    os_task_create(&_appTaskHandle, "BLE_Peripheral_Task", BLEMainTask, 0, 256*4, 1);
+    os_task_create(&_appTaskHandle, "BLE_Peripheral_Task", BLEMainTask, 0, 512*4, 1);
     if (BTDEBUG) printf("Task create\r\n");
 
     bt_coex_init();


### PR DESCRIPTION
- Feature: Bug fix for BLE examples, insufficient stack size that will cause the read callback to hang.


## Tests and Environments 
Please describe on what Hardware, SDK, IDE, OS that tested this Pull Request and how if necessary.  \
*eg.*
- AMB23
- ambd_arduino V3.1.8
- Arduino IDE 2.3.4
- Windows 10, Ubuntu

